### PR TITLE
✨ Convert portal links to relative to avoid homepage flash on click

### DIFF
--- a/apps/portal/src/tests/App.test.js
+++ b/apps/portal/src/tests/App.test.js
@@ -1,0 +1,34 @@
+import App from '../App';
+import setupGhostApi from '../utils/api';
+import {appRender} from '../utils/test-utils';
+import {site as FixtureSite, member as FixtureMember} from '../utils/test-fixtures';
+
+describe('App', function () {
+    beforeEach(function () {
+        // Stub window.location with a URL object so we have an expected origin
+        const location = new URL('http://example.com');
+        delete window.location;
+        window.location = location;
+    });
+
+    test('transforms portal links on render', async () => {
+        const link = document.createElement('a');
+        link.setAttribute('href', 'http://example.com/#/portal/signup');
+        document.body.appendChild(link);
+
+        const ghostApi = setupGhostApi({siteUrl: 'http://example.com'});
+        ghostApi.init = jest.fn(() => {
+            return Promise.resolve({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.free
+            });
+        });
+        const utils = appRender(
+            <App api={ghostApi} />
+        );
+
+        await utils.findByTitle(/portal-popup/i);
+
+        expect(link.getAttribute('href')).toBe('#/portal/signup');
+    });
+});

--- a/apps/portal/src/tests/unit/transform-portal-anchor-to-relative.test.js
+++ b/apps/portal/src/tests/unit/transform-portal-anchor-to-relative.test.js
@@ -1,0 +1,37 @@
+import {transformPortalAnchorToRelative} from '../../utils/transform-portal-anchor-to-relative';
+
+// NOTE: window.location.origin = http://localhost:3000
+
+describe('transformPortalAnchorToRelative', function () {
+    test('ignores non-portal links', function () {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', 'http://localhost:3000/#/signup');
+        transformPortalAnchorToRelative(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('http://localhost:3000/#/signup');
+    });
+
+    test('ignores already-relative links', function () {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', '#/portal/signup');
+        transformPortalAnchorToRelative(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('#/portal/signup');
+    });
+
+    test('ignores external links', function () {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', 'https://example.com/#/portal/signup');
+        transformPortalAnchorToRelative(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('https://example.com/#/portal/signup');
+    });
+
+    test('converts absolute to a relative link', function () {
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', 'http://localhost:3000/#/portal/signup');
+        transformPortalAnchorToRelative(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('#/portal/signup');
+    });
+});

--- a/apps/portal/src/utils/transform-portal-anchor-to-relative.js
+++ b/apps/portal/src/utils/transform-portal-anchor-to-relative.js
@@ -1,0 +1,22 @@
+export function transformPortalAnchorToRelative(anchor) {
+    const href = anchor.getAttribute('href');
+    const url = new URL(href, window.location.origin);
+
+    // ignore non-portal links
+    if (!url.hash || !url.hash.startsWith('#/portal')) {
+        return;
+    }
+
+    // ignore already-relative links
+    if (href.startsWith('#/portal')) {
+        return;
+    }
+
+    // ignore external links
+    if (url.origin !== window.location.origin) {
+        return;
+    }
+
+    // convert to a relative link
+    anchor.setAttribute('href', url.hash);
+}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/PLG-190

- often when adding portal links to your own site pages the URLs are added as absolute on the site's homepage due to copy+paste from displayed URLs in Admin
- when clicking absolute portal URLs the homepage is first loaded before the Portal popup is shown resulting in a slower and flashier experience
- added a transform for all local portal URLs on the page when Portal is initialized so links open the Portal popup immediately on the current page

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
