### PR TITLE
Added gscan to renovate ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "codemirror",
       "faker",
       "ember-cli-code-coverage",
-      "ember-cli-terser"
+      "ember-cli-terser",
+      "gscan"
     ],
     "ignorePaths": [
       "test",


### PR DESCRIPTION
no ref

The gscan library is one that we intentionally want to keep out of sync whenever we're releasing new theme features, as the latest version is publicly available at themes.ghost.org for theme devs to check their builds. After we give an appropriate lead time for updates, *then* we want to update Ghost to require them.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!
